### PR TITLE
main.html: Fix Wikipedia logo

### DIFF
--- a/public_html/vue_components/main.html
+++ b/public_html/vue_components/main.html
@@ -42,7 +42,7 @@ div.tool_group:hover {
 		<div style='flex-grow: 1; text-align: center;'>
 			<div style='height:250px;'>
 				<a href='https://en.wikipedia.org'>
-					<img src='https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Wikipedia_svg_logo-en.svg/209px-Wikipedia_svg_logo-en.svg.png' />
+					<img src='https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Wikipedia-logo-v2-en.svg/209px-Wikipedia-logo-v2-en.svg.png' />
 				</a>
 			</div>
 			<div tt='desc_wikipedia'></div>


### PR DESCRIPTION
The previous file was for the old (v1) logo.

(I was going to add this to #1 but you merged it too quickly for me ^^)